### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/syedhidayath1026/fb9340f3-6d9a-49f1-af4b-52085d229108/84459ebb-d1fb-439f-9f70-f979ac9f62ba/_apis/work/boardbadge/6086b53d-d250-43ed-a838-1063e2f5d53f)](https://dev.azure.com/syedhidayath1026/fb9340f3-6d9a-49f1-af4b-52085d229108/_boards/board/t/84459ebb-d1fb-439f-9f70-f979ac9f62ba/Microsoft.RequirementCategory)
 ---
 topic: HTML Hello World
 languages:


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#531](https://dev.azure.com/syedhidayath1026/fb9340f3-6d9a-49f1-af4b-52085d229108/_workitems/edit/531). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.